### PR TITLE
ä und ü korrigiert

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,10 +143,10 @@
 									<a href="http://www.jobcenter-ge.de/lang_de/nn_586588/Argen/ArgeNuernberg/SharedDocs/Downloads/Schriftenreihen/U__25__Teil__1,templateId=raw,property=publicationFile.pdf" class="">Band 4: Menschen bis 25 </a><br>
 
 
-									<a href="http://www.jobcenter-ge.de/lang_de/nn_586588/Argen/ArgeNuernberg/SharedDocs/Downloads/Schriftenreihen/Gesundheit,templateId=raw,property=publicationFile.pdf" class="">Band 5: Integrationsstrategien für Frauen </a><br>
+									<a href="http://www.jobcenter-ge.de/lang_de/nn_586588/Argen/ArgeNuernberg/SharedDocs/Downloads/Schriftenreihen/Gesundheit,templateId=raw,property=publicationFile.pdf" class="">Band 5: Integrationsstrategien für Frauen </a><br>
 
 
-									<a href="http://www.jobcenter-ge.de/lang_de/nn_586588/Argen/ArgeNuernberg/SharedDocs/Downloads/Schriftenreihen/Gesundheit,templateId=raw,property=publicationFile.pdf" class="">Band 6: Gesundheit – Leitfaden für Integrationsfachkräfte </a><br>
+									<a href="http://www.jobcenter-ge.de/lang_de/nn_586588/Argen/ArgeNuernberg/SharedDocs/Downloads/Schriftenreihen/Gesundheit,templateId=raw,property=publicationFile.pdf" class="">Band 6: Gesundheit – Leitfaden für Integrationsfachkräfte </a><br>
 
 									</p>
 								</header>


### PR DESCRIPTION
Wenn man aus PDF-Dateien Umlaute kopiert werden die falschen Unicode-Zeichen verwendet. Das sorgt dafür, dass die Punkte hinter dem a und u erscheinen und nicht darüber